### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'java'
 
 defaultTasks 'clean', 'build'
 
-sourceCompatibility = 1.6
+sourceCompatibility = 1.8
 
 rootProject.version=''
 buildDir='library'
@@ -32,6 +32,6 @@ sourceSets {
 }
 
 dependencies {
-    provided group: 'org.processing', name: 'core', version: '3.3.6'
+    provided group: 'org.processing', name: 'core', version: '3.3.7'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }


### PR DESCRIPTION
I tried to build a library based on this template but an error occurred.
Compiling with the recommended JDK (JDK 8) requires some changes.
Please update some numbers in the build.gradle to the latest version.