### PR TITLE
roll back the core version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,6 @@ sourceSets {
 }
 
 dependencies {
-    provided group: 'org.processing', name: 'core', version: '3.5.4'
+    provided group: 'org.processing', name: 'core', version: '3.3.7'
     testImplementation group: 'junit', name: 'junit', version: '4.12'
 }


### PR DESCRIPTION
The current latest core version is 3.3.7, so please roll back the version.

[https://repo.maven.apache.org/maven2/org/processing/core/](https://repo.maven.apache.org/maven2/org/processing/core/)
![スクリーンショット 2021-08-25 20 51 11](https://user-images.githubusercontent.com/11240403/130785680-7c996dcc-b86b-4124-bf8e-b3adaf12771f.png)
